### PR TITLE
Add safe memory allocation wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ src/lsp/language-support/client/out
 
 # ignore macOS hidden files
 .DS_Store
+
+# Bear / clangd
+compile_commands.json

--- a/src/c_libs/memory/memory.c
+++ b/src/c_libs/memory/memory.c
@@ -17,8 +17,11 @@
  */
 
 #include "memory.h"
+#include <stdarg.h>
 #include <stdio.h>
+#include <stdnoreturn.h>
 #include <string.h>
+#include <stdint.h>
 
 #if defined(_WIN32)
 #include <malloc.h>
@@ -38,6 +41,77 @@
     fprintf(stderr, __VA_ARGS__);                                              \
   } while (0)
 #endif
+
+/**
+ * @brief Prints a fatal error message and exits the program.
+ * @param fmt Format string for the error message.
+ * @param ... Additional arguments for the format string.
+ */
+noreturn void die(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    fprintf(stderr, "fatal: ");
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
+    va_end(ap);
+    exit(EXIT_FAILURE);
+}
+
+/* Allocation wrappers */
+
+/**
+ * @brief Allocates memory and checks for allocation failure. If !size it will
+ * still return a valid pointer that can be freed.
+ * @param size Number of bytes to allocate.
+ * @return Pointer to the allocated memory on success.
+ */
+void *xmalloc(size_t size) {
+    void *ret = malloc(size);
+
+    /* handle malloc(0) as a valid pointer */
+    if (!ret && !size)
+        ret = malloc(1);
+    if (!ret)
+        die("malloc: failed to allocate %zu bytes", size);
+    return ret;
+}
+
+/**
+ * @brief Allocates zero-init memory and checks for allocation failure. If !size
+ * it will still return a valid pointer.
+ * @param nr Number of elements to allocate.
+ * @param size Size of each element.
+ * @return Pointer to the allocated memory on success.
+ */
+void *xcalloc(size_t nr, size_t size) {
+    void *ret;
+
+    if (size && nr > SIZE_MAX / size)
+        die("calloc: size overflow");
+
+    ret = calloc(nr, size);
+    if (!ret && (!nr || !size))
+        ret = calloc(1, 1);
+    if (!ret)
+        die("calloc: failed to allocate %zu bytes", nr * size);
+    return ret;
+}
+
+/**
+ * @brief Duplicates a string and checks for allocation failure.
+ * @param str The string to duplicate.
+ * @return Pointer to the duplicated string on success.
+ */
+char *xstrdup(const char *str) {
+    char *ret;
+
+    if (!str)
+        die("xstrdup: string is NULL");
+    ret = strdup(str);
+    if (!ret)
+        die("xstrdup: failed to duplicate string");
+    return ret;
+}
 
 /**
  * @brief Returns the maximum of two size_t values.

--- a/src/c_libs/memory/memory.h
+++ b/src/c_libs/memory/memory.h
@@ -43,6 +43,7 @@
 #include <stdalign.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdnoreturn.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -222,6 +223,37 @@ bool growable_array_init(GrowableArray *arr, ArenaAllocator *arena,
  * @return Pointer to the new element's memory slot.
  */
 void *growable_array_push(GrowableArray *arr);
+
+/**
+ * @brief Prints a fatal error message and exits the program.
+ * @param fmt Format string for the error message.
+ * @param ... Additional arguments for the format string.
+ */
+noreturn void die(const char *fmt, ...);
+
+/**
+ * @brief Allocates memory and checks for allocation failure. If !size it will
+ * still return a valid pointer that can be freed.
+ * @param size Number of bytes to allocate.
+ * @return Pointer to the allocated memory on success.
+ */
+void *xmalloc(size_t size);
+
+/**
+ * @brief Allocates zero-init memory and checks for allocation failure. If !size
+ * it will still return a valid pointer.
+ * @param nr Number of elements to allocate.
+ * @param size Size of each element.
+ * @return Pointer to the allocated memory on success.
+ */
+void *xcalloc(size_t nr, size_t size);
+
+/**
+ * @brief Duplicates a string and checks for allocation failure.
+ * @param str The string to duplicate.
+ * @return Pointer to the duplicated string on success.
+ */
+char *xstrdup(const char *str);
 
 #ifdef __cplusplus
 }

--- a/src/llvm/core/llvm.c
+++ b/src/llvm/core/llvm.c
@@ -245,15 +245,8 @@ bool compile_modules_to_objects(CodeGenContext *ctx, const char *output_dir) {
   }
 
   // Allocate resources
-  ModuleCompileTask *tasks = malloc(sizeof(ModuleCompileTask) * module_count);
-  pthread_t *threads = malloc(sizeof(pthread_t) * module_count);
-
-  if (!tasks || !threads) {
-    fprintf(stderr, "Failed to allocate memory for compilation tasks\n");
-    free(tasks);
-    free(threads);
-    return false;
-  }
+  ModuleCompileTask *tasks = xmalloc(sizeof(ModuleCompileTask) * module_count);
+  pthread_t *threads = xmalloc(sizeof(pthread_t) * module_count);
 
   // Initialize tasks
   size_t i = 0;
@@ -341,8 +334,8 @@ void set_current_module(CodeGenContext *ctx, ModuleCompilationUnit *module) {
 void add_symbol_to_module(ModuleCompilationUnit *module, const char *name,
                           LLVMValueRef value, LLVMTypeRef type,
                           bool is_function) {
-  LLVM_Symbol *sym = (LLVM_Symbol *)malloc(sizeof(LLVM_Symbol));
-  sym->name = strdup(name);
+  LLVM_Symbol *sym = (LLVM_Symbol *)xmalloc(sizeof(LLVM_Symbol));
+  sym->name = xstrdup(name);
   sym->value = value;
   sym->type = type;
   sym->is_function = is_function;
@@ -583,7 +576,7 @@ LLVMLinkage get_function_linkage(AstNode *node) {
 
 char *process_escape_sequences(const char *input) {
   size_t len = strlen(input);
-  char *output = malloc(len + 1);
+  char *output = xmalloc(len + 1);
   size_t out_idx = 0;
 
   for (size_t i = 0; i < len; i++) {

--- a/src/llvm/module/module_handles.c
+++ b/src/llvm/module/module_handles.c
@@ -1,4 +1,5 @@
 #include "../llvm.h"
+#include "../../c_libs/memory/memory.h"
 #include <stdlib.h>
 
 static FieldToStructEntry *field_to_struct_buckets[SYMBOL_HASH_SIZE] = {0};
@@ -18,7 +19,7 @@ unsigned int hash_string(const char *str) {
 // Symbol cache operations
 void init_symbol_cache(void) {
   if (!global_symbol_cache) {
-    global_symbol_cache = (SymbolHashTable *)calloc(1, sizeof(SymbolHashTable));
+    global_symbol_cache = (SymbolHashTable *)xcalloc(1, sizeof(SymbolHashTable));
   }
 }
 
@@ -42,8 +43,8 @@ void cache_symbol(const char *module_name, const char *symbol_name,
 
   // Add new entry
   SymbolHashEntry *new_entry =
-      (SymbolHashEntry *)malloc(sizeof(SymbolHashEntry));
-  new_entry->key = strdup(key);
+      (SymbolHashEntry *)xmalloc(sizeof(SymbolHashEntry));
+  new_entry->key = xstrdup(key);
   new_entry->symbol = symbol;
   new_entry->next = global_symbol_cache->buckets[bucket];
   global_symbol_cache->buckets[bucket] = new_entry;
@@ -72,7 +73,7 @@ LLVM_Symbol *lookup_cached_symbol(const char *module_name,
 // Struct cache operations
 void init_struct_cache(void) {
   if (!global_struct_cache) {
-    global_struct_cache = (StructHashTable *)calloc(1, sizeof(StructHashTable));
+    global_struct_cache = (StructHashTable *)xcalloc(1, sizeof(StructHashTable));
   }
 }
 
@@ -90,8 +91,8 @@ void cache_struct(const char *name, StructInfo *info) {
   }
 
   StructHashEntry *new_entry =
-      (StructHashEntry *)malloc(sizeof(StructHashEntry));
-  new_entry->name = strdup(name);
+      (StructHashEntry *)xmalloc(sizeof(StructHashEntry));
+  new_entry->name = xstrdup(name);
   new_entry->info = info;
   new_entry->next = global_struct_cache->buckets[bucket];
   global_struct_cache->buckets[bucket] = new_entry;
@@ -136,8 +137,8 @@ void cache_struct_field(const char *field_name, StructInfo *info) {
     }
   }
 
-  FieldToStructEntry *new_entry = malloc(sizeof(FieldToStructEntry));
-  new_entry->field_name = strdup(field_name);
+  FieldToStructEntry *new_entry = xmalloc(sizeof(FieldToStructEntry));
+  new_entry->field_name = xstrdup(field_name);
   new_entry->struct_info = info;
   new_entry->next = field_to_struct_buckets[bucket];
   field_to_struct_buckets[bucket] = new_entry;


### PR DESCRIPTION
Throughout the code there is a common pattern of allocation + check for allocation failure or no check at all. This makes the code susceptible to seg fault or adds noise repeating NULL checks.

This commit series adds main used allocation functions wrappers:
- `malloc` -> `xmalloc`
- `calloc` -> `xcalloc`
- `strdup` -> `xstrdup`

> The wrappers can and should be extended as missing from this commit allocation functions are used. e.g: 
> `realloc` is not currently used but in a future if it's needed a wrapper should be created.

Two files have been refactored to use the allocation wrappers:
- `llvm.c`
- `module_handles.c`

**worth noting**:

```c
  // Allocate resources
  ModuleCompileTask *tasks = malloc(sizeof(ModuleCompileTask) * module_count);
  pthread_t *threads = malloc(sizeof(pthread_t) * module_count);

  if (!tasks || !threads) {
    fprintf(stderr, "Failed to allocate memory for compilation tasks\n");
    free(tasks);
    free(threads);
    return false;
  }
```

with the refactor becomes

```c
  // Allocate resources
  ModuleCompileTask *tasks = xmalloc(sizeof(ModuleCompileTask) * module_count);
  pthread_t *threads = xmalloc(sizeof(pthread_t) * module_count);
```

`xmalloc` calls to `die` a new introduced function along with the wrapper that fatally exits the program.
While the previous code returned `false` instead of  fatal exiting, there is no "panic" mode that tries to make the program compilable therefore the `false` propagates up to `main` and ends up dying with a `"Failed to generate LLVM modules"`, while the error is true, the fail doesn't come from the code itself but from OOM.

With the wrapper it will directly exit the program with `"fatal: malloc: failed to allocate x bytes"`, which I believe it is more descriptive.

Nit: `memory.c` uses 2 space indentation but coding guidelines asks for 4 while also asking to follow the existing code as reference. wrappers follow 4 space indentation. It can be changed to follow the rest of `memory.c` but I would change `memory.c` to follow the 4 space indentation instead.

---

**Not related with the code on the series but worth knowing for following commits**:

1.
`ALIGNED_ALLOC` its not being used in `buffer_create`
At the top of the file there is this:
```c
#define ALIGNED_ALLOC(sz, align) ...
#define ALIGNED_FREE(ptr) ...
```
But later this is what it is being used
```c
#if defined(_WIN32)
  void *raw = _aligned_malloc(aligned_total_size, alignment);
#else
  void *raw = aligned_alloc(alignment, aligned_total_size);
#endif
```

2.
To append to the arena at `arena_add_buffer` it's a O(n) operation, it could become a O(1) having a pointer to the tail at `ArenaAllocator`.

3.
`growable_array_push` redo's what `arena_realloc` does. should call `arena_realloc`.

4.
`size_t next_size = max_size(current_size * ARENA_GROWTH_FACTOR, requested_size);` this could overflow.
A tiny helper function like `safe_mult`, `safe_add` would be nice.

5.
No docs at `arena_realloc`

closes #16

-- Pablo