### PR TITLE
added configure flags to auto generated config.h file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,16 +1,30 @@
-project('luma', 'c',
-  version : 'git',
+project(
+  'luma',
+  'c', 'cpp',
+  version : '0.2.9',
   license : 'MIT',
-  default_options : [
-    'c_std=c11',
-    'warning_level=2',
-    'buildtype=release',
-  ]
+  default_options : ['c_std=c11', 'warning_level=2']
 )
 
-add_languages('cpp', native : false, required : true)
-
 cc = meson.get_compiler('c')
+
+config_vars = {
+  'LUMA_VERSION': meson.project_version(),
+  'LUMA_OS': host_machine.system(),
+  'LUMA_ARCH': host_machine.cpu_family(),
+  'LUMA_COMPILER': cc.get_id(),
+  'LUMA_COMPILER_VERSION': cc.version(), 
+}
+
+cfg_data = configuration_data()
+foreach key, value : config_vars
+  cfg_data.set_quoted(key, value)
+endforeach
+
+configure_file(
+  output: 'config.h',
+  configuration: cfg_data,
+)
 
 llvm_dep = dependency('llvm',
   modules  : ['core', 'support', 'irreader', 'target', 'analysis', 'all-targets'],
@@ -108,17 +122,17 @@ sources = files(
   'src/typechecker/type.c',
 )
 
-system = host_machine.system()
-if system == 'darwin'
-  rpath_arg = '-Wl,-rpath,@executable_path'
+if host_machine.system() == 'darwin'
+  rpath_val = '@loader_path'
 else
-  rpath_arg = '-Wl,-rpath,$ORIGIN'
+  rpath_val = '$ORIGIN'
 endif
 
 executable('luma',
   sources,
-  dependencies : llvm_dep,
-  install      : true,
-  install_dir  : get_option('bindir'),
-  link_args    : [rpath_arg],
+  dependencies  : llvm_dep,
+  install       : true,
+  install_dir   : get_option('bindir'),
+  build_rpath   : rpath_val,
+  install_rpath : rpath_val,
 )

--- a/src/helper/help.c
+++ b/src/helper/help.c
@@ -1,10 +1,3 @@
-/**
- * @file help.c
- * @brief Implements command-line argument parsing, file reading,
- * help/version/license printing, and token printing with color-highlighted
- * token types.
- */
-
 #include <string.h>
 
 // Platform-specific includes
@@ -122,7 +115,7 @@ int print_help() {
  * @return Always returns 0.
  */
 int print_version() {
-  printf("Luma Compiler %s\n", Luma_Compiler_version);
+  printf("Luma Compiler %s\n", LUMA_VERSION);
   return 0;
 }
 

--- a/src/helper/help.h
+++ b/src/helper/help.h
@@ -18,6 +18,7 @@
 #include "../c_libs/memory/memory.h"
 #include "../lexer/lexer.h"
 #include "../llvm/llvm.h"
+#include "config.h"
 
 /** Macro to access token at index in a token growable array */
 #define TOKEN_AT(i) (((Token *)tokens.data)[(i)])
@@ -27,8 +28,6 @@
 
 /** Enable debug logs for arena allocator (comment to disable) */
 #define DEBUG_ARENA_ALLOC 1
-
-#define Luma_Compiler_version "v0.2.8"
 
 /** Error codes returned by the compiler */
 typedef enum {


### PR DESCRIPTION
I would recommend you change anything wherever you are doing manual detection logic to find what system the user is building from to use the stringed variables defined inside the Meson build file. Meson will auto-generate based off the users current platform, the current list of variables I added are as follows:
- `LUMA_VERSION`: Luma compiler version
- `LUMA_OS`: Host operating system
- `LUMA_ARCH`: Host CPU architecture
- `LUMA_COMPILER`: Compiler used to build the project
- `LUMA_COMPILER_VERSION`: Version of that compiler

I would also recommend you to remove all Doxygen comments from C implementation files and keeping them inside the header definition files. 